### PR TITLE
Get the privacy toggle working again

### DIFF
--- a/components/NoteHeader.jsx
+++ b/components/NoteHeader.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { FOAF, DCTERMS } from "@inrupt/vocab-common-rdf";
 import { getStringNoLocale, getDatetime, getUrl, asUrl } from "@inrupt/solid-client";
 import Link from 'next/link'
@@ -6,6 +7,8 @@ import { Logo } from './logo';
 import Avatar from './Avatar';
 import { getRelativeTime } from '../utils/time';
 import { profilePath } from '../utils/uris';
+import { NoteVisibilityToggle } from './toggles'
+import PrivacyChanger from './PrivacyChanger'
 
 export default function NoteHeader({ concept, conceptName, authorProfile, currentUserProfile, myNote, privacy }) {
 
@@ -16,6 +19,11 @@ export default function NoteHeader({ concept, conceptName, authorProfile, curren
   const noteLastEdit = concept && getDatetime(concept, DCTERMS.modified);
 
   const currentUserAvatarImgSrc = currentUserProfile && getUrl(currentUserProfile, FOAF.img)
+
+  const [privacyUpdatingTo, setPrivacyUpdatingTo] = useState(false)
+  function setNoteVisibilityEnabled(isEnabled) {
+    setPrivacyUpdatingTo(isEnabled ? 'public' : 'private')
+  }
 
   const authorWebId = authorProfile && asUrl(authorProfile)
   const bg = myNote ? ((privacy == 'private') ? "bg-header-gray-gradient" : "bg-header-gradient") : "bg-my-green"
@@ -57,8 +65,14 @@ export default function NoteHeader({ concept, conceptName, authorProfile, curren
       </div>
       <div className="flex flex-row mt-6">
         <div className="flex flex-row h-10 mr-4">
+          {privacyUpdatingTo ? (
+            <PrivacyChanger name={conceptName}
+              changeTo={privacyUpdatingTo} onFinished={() => setPrivacyUpdatingTo(null)} />
+          ) : (
+            <NoteVisibilityToggle className="h-6 mr-8 w-20" enabled={privacy == 'public'}
+              setEnabled={setNoteVisibilityEnabled} />
+          )}
           {/*
-          <NoteVisibilityToggle className="h-6 mr-8 w-20" enabled={visibility} />
           <button type="button" className="ml-7 inline-flex items-center p-2.5 bg-white-a10 border border-white shadow-sm text-sm font-medium rounded-3xl text-white">
             <span>
               Share

--- a/components/PrivacyChanger.jsx
+++ b/components/PrivacyChanger.jsx
@@ -1,0 +1,159 @@
+import {
+  useState,
+  useEffect,
+} from "react";
+import { useWebId, useThing } from "swrlit";
+import {
+  setStringNoLocale,
+  getStringNoLocale,
+  setThing,
+  createSolidDataset,
+  removeThing,
+  getUrl,
+  setUrl,
+} from "@inrupt/solid-client";
+
+import { useWorkspaceContext } from "../contexts/WorkspaceContext";
+
+import {
+  useConceptIndex,
+  useConcept,
+} from "../hooks/concepts";
+import { useWorkspace } from "../hooks/app";
+
+import { deleteResource } from "../utils/fetch";
+import {
+  createNote,
+  noteStorageFileAndThingName,
+} from "../model/note";
+import { US } from "../vocab";
+import { Loader } from './elements'
+
+/*
+This thing is a bit of a beast.
+
+In order to make a note private at the moment we move it into a different directory inside either
+the public or private directories in the user's POD. We do this because we don't want to muck around with
+ACLs quite yet, but this design decision should be revisited soon.
+
+For the moment, this means that we need to do several operations when we change privacy:
+
+1) create the new note resource
+2) update both the public and private index and finally
+3) delete the old note resource
+
+This is why we have so many hooks below, and two separate functions for making a note public or private.
+*/
+export default function PrivacyChanger({ name, changeTo, onFinished, ...rest }) {
+  const [saving, setSaving] = useState(false);
+  const webId = useWebId();
+  const { slug: workspaceSlug } = useWorkspaceContext();
+  const { concept } = useConcept(webId, workspaceSlug, name);
+  const { index: privateIndex, save: savePrivateIndex } = useConceptIndex(
+    webId,
+    workspaceSlug,
+    "private"
+  );
+  const { index: publicIndex, save: savePublicIndex } = useConceptIndex(
+    webId,
+    workspaceSlug,
+    "public"
+  );
+  const { workspace: privateStorage } = useWorkspace(
+    webId,
+    workspaceSlug,
+    "private"
+  );
+  const { workspace: publicStorage } = useWorkspace(
+    webId,
+    workspaceSlug,
+    "public"
+  );
+
+  const publicNoteResourceUrl =
+    publicStorage &&
+    name &&
+    `${getUrl(publicStorage, US.noteStorage)}${noteStorageFileAndThingName(
+      name
+    )}`;
+  const { thing: publicNote, save: savePublicNote, mutate: mutatePublicNote } = useThing(
+    publicNoteResourceUrl
+  );
+
+  const privateNoteResourceUrl =
+    privateStorage &&
+    name &&
+    `${getUrl(privateStorage, US.noteStorage)}${noteStorageFileAndThingName(
+      name
+    )}`;
+  const { thing: privateNote, save: savePrivateNote, mutate: mutatePrivateNote } = useThing(
+    privateNoteResourceUrl
+  );
+
+  async function makePrivate() {
+    await savePrivateNote(
+      setStringNoLocale(
+        privateNote || createNote(),
+        US.slateJSON,
+        getStringNoLocale(publicNote, US.slateJSON)
+      )
+    );
+    await savePrivateIndex(
+      setThing(
+        privateIndex || createSolidDataset(),
+        setUrl(concept, US.storedAt, privateNoteResourceUrl)
+      )
+    );
+    await savePublicIndex(
+      removeThing(publicIndex || createSolidDataset(), concept)
+    );
+    await deleteResource(publicNoteResourceUrl)
+    // mutate here to ensure cached value of public note is not used in the future
+    mutatePublicNote(null, true)
+  }
+  async function makePublic() {
+    await savePublicNote(
+      setStringNoLocale(
+        publicNote || createNote(),
+        US.slateJSON,
+        getStringNoLocale(privateNote, US.slateJSON)
+      )
+    );
+    await savePublicIndex(
+      setThing(
+        publicIndex || createSolidDataset(),
+        setUrl(concept, US.storedAt, publicNoteResourceUrl)
+      )
+    );
+    await savePrivateIndex(
+      removeThing(privateIndex || createSolidDataset(), concept)
+    );
+    await deleteResource(privateNoteResourceUrl);
+    // mutate here to ensure cached value of public note is not used in the future
+    mutatePrivateNote(null, true)
+  }
+  useEffect(function () {
+    if (!saving && publicIndex && privateIndex && concept &&
+      (((changeTo === 'private') && publicNote) ||
+        (changeTo === 'public') && privateNote)) {
+      async function changePrivacy() {
+        setSaving(true)
+        if (changeTo === 'private') {
+          console.log("making private!!")
+          await makePrivate()
+        } else if (changeTo === 'public') {
+          console.log("making public!!")
+          await makePublic()
+        } else {
+          console.warn("indexes are loaded but notes are both falsy! doing nothing for now.")
+        }
+        setSaving(false)
+        onFinished()
+      }
+      changePrivacy()
+    }
+  }, [publicIndex, privateIndex, concept, publicNote, privateNote])
+  return (
+    <Loader />
+  );
+}

--- a/components/toggles.jsx
+++ b/components/toggles.jsx
@@ -21,7 +21,7 @@ export function PrivacyToggle({ enabled, setEnabled }) {
           enabled ? 'translate-x-5' : 'translate-x-0',
           'flex-grow-0 pointer-events-none inline-block h-5 w-5 p-1 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200 flex flex-row items-center justify-center'
         )}>
-        {!enabled && (<Eyeslash className="flex-grow-0"/>)}
+        {!enabled && (<Eyeslash className="flex-grow-0" />)}
       </span>
     </Switch>
   )
@@ -30,25 +30,10 @@ export function PrivacyToggle({ enabled, setEnabled }) {
 export function NoteVisibilityToggle({ enabled, setEnabled }) {
   return (
     <div className="flex flex-row mt-2 h-6 text-xs text-white">
-      <div className="object-center mt-1 opacity-50">
+      <div className="object-center mt-1 opacity-50 mr-2">
         {enabled ? "Public" : "Private"}
       </div>
-      <Switch
-        checked={enabled}
-        onChange={setEnabled}
-        className={classNames(
-          'bg-white bg-opacity-10 relative inline-flex flex-shrink-0 h-6 w-17 ml-2 p-0.5 ring-1 ring-white ring-inset rounded-full cursor-pointer transition-colors ease-in-out duration-200'
-        )}>
-        <span className="sr-only">Use setting</span>
-        <span
-          aria-hidden="true"
-          className={classNames(
-            enabled ? 'translate-x-5' : 'translate-x-0',
-            'flex-grow-0 pointer-events-none inline-block h-5 w-5 p-1 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200 flex flex-row items-center justify-center'
-          )}>
-          {!enabled && (<Eyeslash className="flex-grow-0"/>)}
-        </span>
-      </Switch>
+      <PrivacyToggle enabled={enabled} setEnabled={setEnabled} />
     </div >
   )
 }

--- a/stories/NoteHeader.stories.jsx
+++ b/stories/NoteHeader.stories.jsx
@@ -36,7 +36,7 @@ PublicNoteHeader.args = {
   conceptName,
   authorProfile,
   currentUserProfile,
-  privacy="public",
+  privacy: "public",
   myNote: true
 };
 
@@ -47,7 +47,7 @@ PrivateNoteHeader.args = {
   conceptName,
   authorProfile,
   currentUserProfile,
-  privacy="private",
+  privacy: "private",
   myNote: true
 };
 
@@ -58,6 +58,6 @@ ThirdPartyNoteHeader.args = {
   conceptName,
   authorProfile,
   currentUserProfile,
-  privacy="public",
+  privacy: "public",
   myNote: false
 };


### PR DESCRIPTION
This thing is a bit of a beast.

In order to make a note private at the moment we move it into a different directory inside either
the public or private directories in the user's POD. We do this because we don't want to muck around with
ACLs quite yet, but this design decision should be revisited soon.

For the moment, this means that we need to do several operations when we change privacy:

1) create the new note resource
2) update both the public and private index and finally
3) delete the old note resource

This is why we have so many hooks below, and two separate functions for making a note public or private.