### PR TITLE
Set EmptySlateJSON as the default value

### DIFF
--- a/components/modals/NewNote.jsx
+++ b/components/modals/NewNote.jsx
@@ -25,7 +25,7 @@ const TabId = {
 
 export const NewNote = ({ setOpen, isPublic = false }) => {
   const [pub, setPublic] = useState(isPublic)
-  const [value, setNoteValue] = useState()
+  const [value, setNoteValue] = useState(EmptySlateJSON);
 
   const tabs = [TabId.Concept, TabId.Bookmark];
   const [selectedTab, setSelectedTab] = useState(tabs[0]);


### PR DESCRIPTION
This solves a bug where if you tried to create a note but you have never
typed in the editor yet (i.e. you just add a title) the note won't be
created.