### PR TITLE
Remove the try catch so Vercel catches the error

### DIFF
--- a/pages/api/fetch-og-tags/[encodedUrl].js
+++ b/pages/api/fetch-og-tags/[encodedUrl].js
@@ -11,15 +11,11 @@ import * as ogs from 'open-graph-scraper';
 export default async function handler(req, res) {
   const { encodedUrl } = req.query;
   const url = decodeURIComponent(encodedUrl);
-  const options = { url }; 
+  const options = { url };
   console.log(`fetching OG tags for ${url}:`);
-  try {
-    const { error, result, response } = await ogs(options);
 
-    console.log(result);
-    res.json(result);
-  } catch (e) {
-    res.status(404);
-    res.json({});
-  }
+  const { error, result, response } = await ogs(options);
+
+  console.log(result);
+  res.json(result);
 };


### PR DESCRIPTION
Some URLs I was trying to bookmark were returning a 404 from this even though they shouldn't have been. Using a try catch hides the error behind a 404, so remove the try catch so we get more detailed info in the Vercel Error logs

https://vercel.com/docs/concepts/functions/serverless-functions#error-logs