### PR TITLE
Remove math and legal plugins

### DIFF
--- a/components/Plate/autoformat/autoformatRules.ts
+++ b/components/Plate/autoformat/autoformatRules.ts
@@ -1,8 +1,5 @@
 import {
   autoformatArrow,
-  autoformatLegal,
-  autoformatLegalHtml,
-  autoformatMath,
   autoformatPunctuation,
   autoformatSmartQuotes,
 } from '@udecode/plate';
@@ -16,8 +13,5 @@ export const autoformatRules = [
   ...autoformatMarks,
   ...autoformatSmartQuotes,
   ...autoformatPunctuation,
-  ...autoformatLegal,
-  ...autoformatLegalHtml,
   ...autoformatArrow,
-  ...autoformatMath,
 ];


### PR DESCRIPTION
The math plugin blocks me from writing a url out manually (i.e.
https://) because it turns the // into a division sign.