### PR TITLE
Wrap maybeNewConcept in null `name` guards

### DIFF
--- a/hooks/concepts.jsx
+++ b/hooks/concepts.jsx
@@ -80,7 +80,7 @@ export function useConceptPrefix(webId, workspaceSlug) {
 }
 
 function maybeNewConcept(workspace, name) {
-  const noteStorageUri = defaultNoteStorageUri(workspace, name)
+  const noteStorageUri = name && defaultNoteStorageUri(workspace, name)
   return (
     name &&
     noteStorageUri &&

--- a/model/note.jsx
+++ b/model/note.jsx
@@ -17,12 +17,12 @@ export function createNote() {
 }
 
 export function noteStorageFileAndThingName(name) {
-  return `${conceptNameToUrlSafeId(name)}.ttl#${thingName}`;
+  return name && `${conceptNameToUrlSafeId(name)}.ttl#${thingName}`;
 }
 
 export function defaultNoteStorageUri(workspace, name) {
   const containerUri = workspace && getUrl(workspace, US.noteStorage);
-  return containerUri && `${containerUri}${noteStorageFileAndThingName(name)}`;
+  return containerUri && name && `${containerUri}${noteStorageFileAndThingName(name)}`;
 }
 
 export function createOrUpdateNoteBody(note, value) {

--- a/utils/uris.js
+++ b/utils/uris.js
@@ -63,7 +63,7 @@ export function noteUriToWebId(noteUri) {
 }
 
 export const conceptNameToUrlSafeId = (name) =>
-  base58.encode(name.toLowerCase());
+  name && base58.encode(name.toLowerCase());
 
 export const urlSafeIdToConceptName = (id) =>
   new TextDecoder().decode(base58.decode(id));


### PR DESCRIPTION
Can't deploy new gates now, or anything that calls `useConcept` with an undefined `name`

Fixes:
https://my-silio.slack.com/archives/C02UB541CGP/p1643053425000900