### PR TITLE
use normalizer to implement tags/mentions

### DIFF
--- a/components/Plate/Editor.jsx
+++ b/components/Plate/Editor.jsx
@@ -1,21 +1,20 @@
-import React, { useCallback, useState, useMemo, useRef, useEffect } from "react";
-import { Transforms, Text, Node, Editor as SlateEditor } from 'slate';
+import React, { useState, useMemo, useRef, useEffect } from "react";
+import { Transforms, Editor as SlateEditor } from 'slate';
 import * as P from "@udecode/plate";
 
 import { comboboxStore, Combobox, createComboboxPlugin } from '@mysilio/plate-ui-combobox'
 import { useWebId } from 'swrlit'
-import { Image as ImageIcon } from "@styled-icons/material/Image";
 import { Link as LinkIcon } from "@styled-icons/material/Link";
 import Link from "next/link";
 
 import Modal from '../Modal';
 import { useWorkspaceContext } from "../../contexts/WorkspaceContext";
-import { notePath, conceptNameToUrlSafeId } from "../../utils/uris";
 import { ELEMENT_CONCEPT, ELEMENT_TAG } from "../../utils/slate";
 import { useImageUploadUri } from "../../hooks/uris";
 import { ImageUploadAndEditor } from "../ImageUploader";
 import { ExternalLinkIcon } from '../icons'
 import { autoformatRules } from './autoformat/autoformatRules'
+import { createConceptPlugin, createConceptStartPlugin, createConceptEndPlugin} from './plugins/concept'
 
 import {
   ToolbarButtonsList,
@@ -109,144 +108,7 @@ const optionsResetBlockTypePlugin = {
   ],
 };
 
-const conceptRegex = /\[\[(.*)\]\](.*)/
 
-function hasConceptParent(editor, path) {
-  const parent = Node.get(editor, path.slice(0, -1))
-  if (parent.type === ELEMENT_CONCEPT) {
-    return true
-  } else {
-    return false
-  }
-}
-
-export const withConcepts = editor => {
-  const { normalizeNode } = editor
-
-  editor.normalizeNode = entry => {
-    const [node, path] = entry
-    if (Text.isText(node) && !hasConceptParent(editor, path)) {
-      const conceptMatch = node.text.match(conceptRegex)
-      if (conceptMatch) {
-        const { index, 0: match, 1: name } = conceptMatch
-        const at = { anchor: { path, offset: index }, focus: { path, offset: index + match.length } }
-        Transforms.wrapNodes(editor, { type: ELEMENT_CONCEPT, children: [] }, { at, split: true })
-        return
-      }
-    } else if (node.type === ELEMENT_CONCEPT) {
-
-      // Migrate from old to new concept format
-      if (node.value) {
-        Transforms.setNodes(editor, {
-          name: node.value
-        }, { at: path })
-        const childText = `[[${node.value}]]`
-        if (node.children[0].text != childText) {
-          const childTextStart = { path: [...path, 0], offset: 0 }
-          const lastChildIndex = (node.children.length - 1)
-          const lastTextPositionIndex = node.children[lastChildIndex].text.length
-          const childTextEnd = { path: [...path, lastChildIndex], offset: lastTextPositionIndex }
-          const childTextRange = { anchor: childTextStart, focus: childTextEnd }
-          Transforms.insertText(editor, childText, { at: childTextRange })
-        }
-        Transforms.unsetNodes(editor, 'value', { at: path })
-        return
-      }
-
-      const conceptMatch = Node.string(node).match(conceptRegex)
-      if (conceptMatch) {
-        const [_, name, extra] = conceptMatch
-
-        // make sure name always matches text
-        if (node.name !== name) {
-          Transforms.setNodes(editor, { name }, { at: path })
-          return
-        }
-
-        // make sure a concept doesn't eat the text after it
-        if (extra !== '') {
-          const childText = `[[${node.name}]]`
-          Transforms.splitNodes(editor, {
-            at: { path: [...path, 0], offset: childText.length },
-            match: n => (n.type === ELEMENT_CONCEPT)
-          })
-          return
-        }
-      } else {
-        Transforms.unwrapNodes(editor, { match: n => n.type === ELEMENT_CONCEPT })
-        return
-      }
-    }
-
-    normalizeNode(entry)
-  }
-
-  return editor
-}
-
-const LEAF_CONCEPT_START = 'conceptLeafStart'
-const LEAF_CONCEPT_END = 'conceptLeafEnd'
-
-const createConceptPlugin = P.createPluginFactory({
-  key: ELEMENT_CONCEPT,
-  isElement: true,
-  isInline: true,
-  withOverrides: withConcepts,
-  decorate: (editor, options) => ([node, path]) => {
-    if (node.type === 'concept') {
-      const textPath = [...path, 0]
-      const textLength = node.children[0].text.length
-      return [
-        {
-          anchor: { path: textPath, offset: 0 },
-          focus: { path: textPath, offset: 2 },
-          [LEAF_CONCEPT_START]: true
-        },
-        {
-          anchor: { path: textPath, offset: textLength - 2 },
-          focus: { path: textPath, offset: textLength },
-          [LEAF_CONCEPT_END]: true,
-          conceptName: node.name
-        }
-      ]
-    }
-  }
-})
-
-function ConceptStartLeaf({ children }) {
-  return (
-    <span className="opacity-50 group-hover:opacity-100">
-      {children}
-    </span>
-  )
-}
-function ConceptEndLeaf({ children, leaf }) {
-  const { webId, slug: workspaceSlug } = useWorkspaceContext();
-  const name = leaf.conceptName
-  const url = notePath(webId, workspaceSlug, name)
-  return (
-    <span className="opacity-50 group-hover:opacity-100 relative">
-      {children}
-      <Link href={url || ""}>
-        <a contentEditable={false} className="hidden group-hover:inline">
-          <ExternalLinkIcon className="h-4 w-4 inline" />
-        </a>
-      </Link>
-    </span>
-
-  )
-}
-
-const createConceptStartPlugin = P.createPluginFactory({
-  key: LEAF_CONCEPT_START,
-  isLeaf: true,
-  component: ConceptStartLeaf
-})
-const createConceptEndPlugin = P.createPluginFactory({
-  key: LEAF_CONCEPT_END,
-  isLeaf: true,
-  component: ConceptEndLeaf
-})
 
 const defaultPlugins = [
   P.createHeadingPlugin({ options: { levels: 3 } }),

--- a/components/Plate/Editor.jsx
+++ b/components/Plate/Editor.jsx
@@ -16,9 +16,10 @@ import { ImageUploadAndEditor } from "../ImageUploader";
 import { ExternalLinkIcon } from '../icons'
 import { autoformatRules } from './autoformat/autoformatRules'
 import {
-   createConceptPlugin, createConceptStartPlugin, createConceptEndPlugin,
-   LEAF_CONCEPT_START, LEAF_CONCEPT_END
+  createConceptPlugin, createConceptStartPlugin, createConceptEndPlugin,
+  LEAF_CONCEPT_START, LEAF_CONCEPT_END
 } from './plugins/concept'
+import { createTagPlugin } from './plugins/tag'
 
 import {
   ToolbarButtonsList,
@@ -56,7 +57,7 @@ function ConceptEndLeaf({ children, leaf }) {
       {children}
       <Link href={url || ""}>
         <a contentEditable={false} className="hidden group-hover:inline">
-          <ExternalLinkIcon className="h-4 w-4 inline" />
+          <ExternalLinkIcon className="h-4 w-4 inline hover:scale-125" />
         </a>
       </Link>
     </span>
@@ -64,13 +65,17 @@ function ConceptEndLeaf({ children, leaf }) {
   )
 }
 
-const TagElement = (m) => {
+const TagElement = ({ attributes, element, children }) => {
   const { slug: workspaceSlug } = useWorkspaceContext();
-  const tag = fromMentionable(m);
   return (
-    <Link href={`/tags/${workspaceSlug}/${tag}`}>
-      <a className="text-lagoon">#{tag}</a>
-    </Link>
+    <span className="text-lagoon group" {...attributes}>
+      {children}
+      <Link href={`/tags/${workspaceSlug}/${element.name}`}>
+        <a contentEditable={false} className="hidden group-hover:inline">
+          <ExternalLinkIcon className="h-4 w-4 inline hover:scale-125" />
+        </a>
+      </Link>
+    </span>
   )
 };
 
@@ -106,9 +111,7 @@ const components = P.createPlateUI({
   [ELEMENT_CONCEPT]: ConceptElement,
   [LEAF_CONCEPT_START]: ConceptStartLeaf,
   [LEAF_CONCEPT_END]: ConceptEndLeaf,
-  [ELEMENT_TAG]: P.withProps(P.MentionElement, {
-    renderLabel: TagElement,
-  }),
+  [ELEMENT_TAG]: TagElement,
   [P.ELEMENT_MENTION]: P.withProps(P.MentionElement, {
     renderLabel: MentionElement,
   }),
@@ -163,10 +166,10 @@ const defaultPlugins = [
   // for now we need to support both combobox plugins
   P.createComboboxPlugin(),
   P.createMentionPlugin({ key: P.ELEMENT_MENTION, options: { trigger: '@' } }),
-  P.createMentionPlugin({ key: ELEMENT_TAG, options: { trigger: '#' } }),
   createConceptPlugin(),
   createConceptStartPlugin(),
   createConceptEndPlugin(),
+  createTagPlugin(),
   P.createSoftBreakPlugin({
     options: {
       rules: [

--- a/components/Plate/Editor.jsx
+++ b/components/Plate/Editor.jsx
@@ -10,11 +10,15 @@ import Link from "next/link";
 import Modal from '../Modal';
 import { useWorkspaceContext } from "../../contexts/WorkspaceContext";
 import { ELEMENT_CONCEPT, ELEMENT_TAG } from "../../utils/slate";
+import { notePath } from "../../utils/uris";
 import { useImageUploadUri } from "../../hooks/uris";
 import { ImageUploadAndEditor } from "../ImageUploader";
 import { ExternalLinkIcon } from '../icons'
 import { autoformatRules } from './autoformat/autoformatRules'
-import { createConceptPlugin, createConceptStartPlugin, createConceptEndPlugin} from './plugins/concept'
+import {
+   createConceptPlugin, createConceptStartPlugin, createConceptEndPlugin,
+   LEAF_CONCEPT_START, LEAF_CONCEPT_END
+} from './plugins/concept'
 
 import {
   ToolbarButtonsList,
@@ -34,6 +38,31 @@ const ConceptElement = ({ attributes, element, children }) => {
     </span>
   );
 };
+
+function ConceptStartLeaf({ children }) {
+  return (
+    <span className="opacity-50 group-hover:opacity-100">
+      {children}
+    </span>
+  )
+}
+
+function ConceptEndLeaf({ children, leaf }) {
+  const { webId, slug: workspaceSlug } = useWorkspaceContext();
+  const name = leaf.conceptName
+  const url = notePath(webId, workspaceSlug, name)
+  return (
+    <span className="opacity-50 group-hover:opacity-100 relative">
+      {children}
+      <Link href={url || ""}>
+        <a contentEditable={false} className="hidden group-hover:inline">
+          <ExternalLinkIcon className="h-4 w-4 inline" />
+        </a>
+      </Link>
+    </span>
+
+  )
+}
 
 const TagElement = (m) => {
   const { slug: workspaceSlug } = useWorkspaceContext();
@@ -75,6 +104,8 @@ const components = P.createPlateUI({
   [P.ELEMENT_H3]: P.withProps(P.StyledElement, { as: "h3" }),
   [P.ELEMENT_CODE_BLOCK]: CodeBlockElement,
   [ELEMENT_CONCEPT]: ConceptElement,
+  [LEAF_CONCEPT_START]: ConceptStartLeaf,
+  [LEAF_CONCEPT_END]: ConceptEndLeaf,
   [ELEMENT_TAG]: P.withProps(P.MentionElement, {
     renderLabel: TagElement,
   }),

--- a/components/Plate/plugins/concept.jsx
+++ b/components/Plate/plugins/concept.jsx
@@ -78,8 +78,25 @@ export const withConcepts = editor => {
   return editor
 }
 
+// We'll use these to define decorators that render the
+// special styling for square brackets and links.
+// the algorithm for figuring out where the decorators
+// are applied is specified in the concept plugin below, but we
+// need to register two additional plugins to tell Plate that
+// these decorators are leaves. Kind of confusing but apparently how Plate
+// works for now.
 export const LEAF_CONCEPT_START = 'conceptLeafStart'
 export const LEAF_CONCEPT_END = 'conceptLeafEnd'
+
+export const createConceptStartPlugin = createPluginFactory({
+  key: LEAF_CONCEPT_START,
+  isLeaf: true
+})
+
+export const createConceptEndPlugin = createPluginFactory({
+  key: LEAF_CONCEPT_END,
+  isLeaf: true
+})
 
 export const createConceptPlugin = createPluginFactory({
   key: ELEMENT_CONCEPT,
@@ -105,14 +122,4 @@ export const createConceptPlugin = createPluginFactory({
       ]
     }
   }
-})
-
-export const createConceptStartPlugin = createPluginFactory({
-  key: LEAF_CONCEPT_START,
-  isLeaf: true
-})
-
-export const createConceptEndPlugin = createPluginFactory({
-  key: LEAF_CONCEPT_END,
-  isLeaf: true
 })

--- a/components/Plate/plugins/concept.jsx
+++ b/components/Plate/plugins/concept.jsx
@@ -1,10 +1,6 @@
 import { Transforms, Text, Node, Editor as SlateEditor } from 'slate';
 import { createPluginFactory } from "@udecode/plate";
-import Link from "next/link";
-import { ExternalLinkIcon } from '../../icons'
 
-import { notePath } from "../../../utils/uris";
-import { useWorkspaceContext } from "../../../contexts/WorkspaceContext";
 import { ELEMENT_CONCEPT } from "../../../utils/slate";
 
 const conceptRegex = /\[\[(.*)\]\](.*)/
@@ -82,8 +78,8 @@ export const withConcepts = editor => {
   return editor
 }
 
-const LEAF_CONCEPT_START = 'conceptLeafStart'
-const LEAF_CONCEPT_END = 'conceptLeafEnd'
+export const LEAF_CONCEPT_START = 'conceptLeafStart'
+export const LEAF_CONCEPT_END = 'conceptLeafEnd'
 
 export const createConceptPlugin = createPluginFactory({
   key: ELEMENT_CONCEPT,
@@ -111,38 +107,12 @@ export const createConceptPlugin = createPluginFactory({
   }
 })
 
-function ConceptStartLeaf({ children }) {
-  return (
-    <span className="opacity-50 group-hover:opacity-100">
-      {children}
-    </span>
-  )
-}
-function ConceptEndLeaf({ children, leaf }) {
-  const { webId, slug: workspaceSlug } = useWorkspaceContext();
-  const name = leaf.conceptName
-  const url = notePath(webId, workspaceSlug, name)
-  return (
-    <span className="opacity-50 group-hover:opacity-100 relative">
-      {children}
-      <Link href={url || ""}>
-        <a contentEditable={false} className="hidden group-hover:inline">
-          <ExternalLinkIcon className="h-4 w-4 inline" />
-        </a>
-      </Link>
-    </span>
-
-  )
-}
-
 export const createConceptStartPlugin = createPluginFactory({
   key: LEAF_CONCEPT_START,
-  isLeaf: true,
-  component: ConceptStartLeaf
+  isLeaf: true
 })
 
 export const createConceptEndPlugin = createPluginFactory({
   key: LEAF_CONCEPT_END,
-  isLeaf: true,
-  component: ConceptEndLeaf
+  isLeaf: true
 })

--- a/components/Plate/plugins/concept.jsx
+++ b/components/Plate/plugins/concept.jsx
@@ -1,0 +1,148 @@
+import { Transforms, Text, Node, Editor as SlateEditor } from 'slate';
+import { createPluginFactory } from "@udecode/plate";
+import Link from "next/link";
+import { ExternalLinkIcon } from '../../icons'
+
+import { notePath } from "../../../utils/uris";
+import { useWorkspaceContext } from "../../../contexts/WorkspaceContext";
+import { ELEMENT_CONCEPT } from "../../../utils/slate";
+
+const conceptRegex = /\[\[(.*)\]\](.*)/
+
+function hasConceptParent(editor, path) {
+  const parent = Node.get(editor, path.slice(0, -1))
+  if (parent.type === ELEMENT_CONCEPT) {
+    return true
+  } else {
+    return false
+  }
+}
+
+export const withConcepts = editor => {
+  const { normalizeNode } = editor
+
+  editor.normalizeNode = entry => {
+    const [node, path] = entry
+    if (Text.isText(node) && !hasConceptParent(editor, path)) {
+      const conceptMatch = node.text.match(conceptRegex)
+      if (conceptMatch) {
+        const { index, 0: match, 1: name } = conceptMatch
+        const at = { anchor: { path, offset: index }, focus: { path, offset: index + match.length } }
+        Transforms.wrapNodes(editor, { type: ELEMENT_CONCEPT, children: [] }, { at, split: true })
+        return
+      }
+    } else if (node.type === ELEMENT_CONCEPT) {
+
+      // Migrate from old to new concept format
+      if (node.value) {
+        Transforms.setNodes(editor, {
+          name: node.value
+        }, { at: path })
+        const childText = `[[${node.value}]]`
+        if (node.children[0].text != childText) {
+          const childTextStart = { path: [...path, 0], offset: 0 }
+          const lastChildIndex = (node.children.length - 1)
+          const lastTextPositionIndex = node.children[lastChildIndex].text.length
+          const childTextEnd = { path: [...path, lastChildIndex], offset: lastTextPositionIndex }
+          const childTextRange = { anchor: childTextStart, focus: childTextEnd }
+          Transforms.insertText(editor, childText, { at: childTextRange })
+        }
+        Transforms.unsetNodes(editor, 'value', { at: path })
+        return
+      }
+
+      const conceptMatch = Node.string(node).match(conceptRegex)
+      if (conceptMatch) {
+        const [_, name, extra] = conceptMatch
+
+        // make sure name always matches text
+        if (node.name !== name) {
+          Transforms.setNodes(editor, { name }, { at: path })
+          return
+        }
+
+        // make sure a concept doesn't eat the text after it
+        if (extra !== '') {
+          const childText = `[[${node.name}]]`
+          Transforms.splitNodes(editor, {
+            at: { path: [...path, 0], offset: childText.length },
+            match: n => (n.type === ELEMENT_CONCEPT)
+          })
+          return
+        }
+      } else {
+        Transforms.unwrapNodes(editor, { match: n => n.type === ELEMENT_CONCEPT })
+        return
+      }
+    }
+
+    normalizeNode(entry)
+  }
+
+  return editor
+}
+
+const LEAF_CONCEPT_START = 'conceptLeafStart'
+const LEAF_CONCEPT_END = 'conceptLeafEnd'
+
+export const createConceptPlugin = createPluginFactory({
+  key: ELEMENT_CONCEPT,
+  isElement: true,
+  isInline: true,
+  withOverrides: withConcepts,
+  decorate: (editor, options) => ([node, path]) => {
+    if (node.type === 'concept') {
+      const textPath = [...path, 0]
+      const textLength = node.children[0].text.length
+      return [
+        {
+          anchor: { path: textPath, offset: 0 },
+          focus: { path: textPath, offset: 2 },
+          [LEAF_CONCEPT_START]: true
+        },
+        {
+          anchor: { path: textPath, offset: textLength - 2 },
+          focus: { path: textPath, offset: textLength },
+          [LEAF_CONCEPT_END]: true,
+          conceptName: node.name
+        }
+      ]
+    }
+  }
+})
+
+function ConceptStartLeaf({ children }) {
+  return (
+    <span className="opacity-50 group-hover:opacity-100">
+      {children}
+    </span>
+  )
+}
+function ConceptEndLeaf({ children, leaf }) {
+  const { webId, slug: workspaceSlug } = useWorkspaceContext();
+  const name = leaf.conceptName
+  const url = notePath(webId, workspaceSlug, name)
+  return (
+    <span className="opacity-50 group-hover:opacity-100 relative">
+      {children}
+      <Link href={url || ""}>
+        <a contentEditable={false} className="hidden group-hover:inline">
+          <ExternalLinkIcon className="h-4 w-4 inline" />
+        </a>
+      </Link>
+    </span>
+
+  )
+}
+
+export const createConceptStartPlugin = createPluginFactory({
+  key: LEAF_CONCEPT_START,
+  isLeaf: true,
+  component: ConceptStartLeaf
+})
+
+export const createConceptEndPlugin = createPluginFactory({
+  key: LEAF_CONCEPT_END,
+  isLeaf: true,
+  component: ConceptEndLeaf
+})

--- a/components/Plate/plugins/concept.jsx
+++ b/components/Plate/plugins/concept.jsx
@@ -58,7 +58,7 @@ export const withConcepts = editor => {
         }
 
         // make sure a concept doesn't eat the text after it
-        if (extra !== '') {
+        if (extra && extra !== '') {
           const childText = `[[${node.name}]]`
           Transforms.splitNodes(editor, {
             at: { path: [...path, 0], offset: childText.length },

--- a/components/Plate/plugins/mention.jsx
+++ b/components/Plate/plugins/mention.jsx
@@ -1,0 +1,83 @@
+import { Transforms, Text, Node, Editor as SlateEditor } from 'slate';
+import { createPluginFactory, ELEMENT_MENTION } from "@udecode/plate";
+
+// inspired by https://stackoverflow.com/a/60972027
+const mentionRegex = /@(\w{1,100})(.*)/
+
+function hasMentionParent(editor, path) {
+  const parent = Node.get(editor, path.slice(0, -1))
+  if (parent.type === ELEMENT_MENTION) {
+    return true
+  } else {
+    return false
+  }
+}
+
+export const withMentions = editor => {
+  const { normalizeNode } = editor
+
+  editor.normalizeNode = entry => {
+    const [node, path] = entry
+    if (Text.isText(node) && !hasMentionParent(editor, path)) {
+      const mentionMatch = node.text.match(mentionRegex)
+      if (mentionMatch) {
+        const { index, 0: match, 1: name } = mentionMatch
+        const at = { anchor: { path, offset: index }, focus: { path, offset: index + match.length } }
+        Transforms.wrapNodes(editor, { type: ELEMENT_MENTION, children: [] }, { at, split: true })
+        return
+      }
+    } else if (node.type === ELEMENT_MENTION) {
+      // Migrate from old to new mention format
+      if (node.value) {
+        Transforms.setNodes(editor, {
+          name: node.value
+        }, { at: path })
+        const childText = `@${node.value}`
+        if (node.children[0].text != childText) {
+          const childTextStart = { path: [...path, 0], offset: 0 }
+          const lastChildIndex = (node.children.length - 1)
+          const lastTextPositionIndex = node.children[lastChildIndex].text.length
+          const childTextEnd = { path: [...path, lastChildIndex], offset: lastTextPositionIndex }
+          const childTextRange = { anchor: childTextStart, focus: childTextEnd }
+          Transforms.insertText(editor, childText, { at: childTextRange })
+        }
+        Transforms.unsetNodes(editor, 'value', { at: path })
+        return
+      }
+
+      const mentionMatch = Node.string(node).match(mentionRegex)
+      if (mentionMatch) {
+        const [_, name, extra] = mentionMatch
+        // make sure name always matches text
+        if (node.name !== name) {
+          Transforms.setNodes(editor, { name }, { at: path })
+          return
+        }
+
+        // make sure a mention doesn't eat the text after it
+        if (extra && extra !== '') {
+          const childText = `#${node.name}`
+          Transforms.splitNodes(editor, {
+            at: { path: [...path, 0], offset: childText.length },
+            match: n => (n.type === ELEMENT_MENTION)
+          })
+          return
+        }
+      } else {
+        Transforms.unwrapNodes(editor, { match: n => n.type === ELEMENT_MENTION })
+        return
+      }
+    }
+
+    normalizeNode(entry)
+  }
+
+  return editor
+}
+
+export const createMentionPlugin = createPluginFactory({
+  key: ELEMENT_MENTION,
+  isElement: true,
+  isInline: true,
+  withOverrides: withMentions
+})

--- a/components/Plate/plugins/tag.jsx
+++ b/components/Plate/plugins/tag.jsx
@@ -1,0 +1,85 @@
+import { Transforms, Text, Node, Editor as SlateEditor } from 'slate';
+import { createPluginFactory } from "@udecode/plate";
+
+import { ELEMENT_TAG } from "../../../utils/slate";
+
+// inspired by https://stackoverflow.com/a/60972027
+const tagRegex = /#(\w{1,100})(.*)/
+
+function hasTagParent(editor, path) {
+  const parent = Node.get(editor, path.slice(0, -1))
+  if (parent.type === ELEMENT_TAG) {
+    return true
+  } else {
+    return false
+  }
+}
+
+export const withTags = editor => {
+  const { normalizeNode } = editor
+
+  editor.normalizeNode = entry => {
+    const [node, path] = entry
+    if (Text.isText(node) && !hasTagParent(editor, path)) {
+      const tagMatch = node.text.match(tagRegex)
+      if (tagMatch) {
+        const { index, 0: match, 1: name } = tagMatch
+        const at = { anchor: { path, offset: index }, focus: { path, offset: index + match.length } }
+        Transforms.wrapNodes(editor, { type: ELEMENT_TAG, children: [] }, { at, split: true })
+        return
+      }
+    } else if (node.type === ELEMENT_TAG) {
+      // Migrate from old to new tag format
+      if (node.value) {
+        Transforms.setNodes(editor, {
+          name: node.value
+        }, { at: path })
+        const childText = `#${node.value}`
+        if (node.children[0].text != childText) {
+          const childTextStart = { path: [...path, 0], offset: 0 }
+          const lastChildIndex = (node.children.length - 1)
+          const lastTextPositionIndex = node.children[lastChildIndex].text.length
+          const childTextEnd = { path: [...path, lastChildIndex], offset: lastTextPositionIndex }
+          const childTextRange = { anchor: childTextStart, focus: childTextEnd }
+          Transforms.insertText(editor, childText, { at: childTextRange })
+        }
+        Transforms.unsetNodes(editor, 'value', { at: path })
+        return
+      }
+
+      const tagMatch = Node.string(node).match(tagRegex)
+      if (tagMatch) {
+        const [_, name, extra] = tagMatch
+        // make sure name always matches text
+        if (node.name !== name) {
+          Transforms.setNodes(editor, { name }, { at: path })
+          return
+        }
+
+        // make sure a tag doesn't eat the text after it
+        if (extra && extra !== '') {
+          const childText = `#${node.name}`
+          Transforms.splitNodes(editor, {
+            at: { path: [...path, 0], offset: childText.length },
+            match: n => (n.type === ELEMENT_TAG)
+          })
+          return
+        }
+      } else {
+        Transforms.unwrapNodes(editor, { match: n => n.type === ELEMENT_TAG })
+        return
+      }
+    }
+
+    normalizeNode(entry)
+  }
+
+  return editor
+}
+
+export const createTagPlugin = createPluginFactory({
+  key: ELEMENT_TAG,
+  isElement: true,
+  isInline: true,
+  withOverrides: withTags
+})

--- a/utils/slate.js
+++ b/utils/slate.js
@@ -22,7 +22,7 @@ export function getTagNodes(node) {
 }
 
 export function getTagNameFromNode(node) {
-  return node.value;
+  return node.name;
 }
 
 const newElementType = {


### PR DESCRIPTION
extract the concept plugin and duplicate it to use the same UI pattern for tags and mentions.   

I was going to try to abstract this functionality, but due to the way normalizers work (specifically the need to return after a single action) the abstraction doesn't buy us much.

This may get simpler once we feel comfortable removing the migration logic from the normalizer, and I suspect we'll find a way to abstract some of this at some point, but for now I think the code duplication is justified.
