### PR TITLE
fix bidi link pasting

### DIFF
--- a/components/Plate/plugins/concept.jsx
+++ b/components/Plate/plugins/concept.jsx
@@ -3,7 +3,7 @@ import { createPluginFactory } from "@udecode/plate";
 
 import { ELEMENT_CONCEPT } from "../../../utils/slate";
 
-const conceptRegex = /\[\[(.*)\]\](.*)/
+const conceptRegex = /\[\[([^\[\]]*)\]\](.*)/
 
 function hasConceptParent(editor, path) {
   const parent = Node.get(editor, path.slice(0, -1))


### PR DESCRIPTION
currently pasting two bidi links in the same line results in a single bidi link that includes the inner close/open brackets.

this change disallows [ and ] inside a concept which seems reasonable to me?