### PR TITLE
disable node id plugin

### DIFF
--- a/components/Plate/Editor.jsx
+++ b/components/Plate/Editor.jsx
@@ -31,7 +31,7 @@ import {
   createImagePlugin,
   createLinkPlugin,
   createKbdPlugin,
-  createNodeIdPlugin,
+//  createNodeIdPlugin,
   createAutoformatPlugin,
   createResetNodePlugin,
   createComboboxPlugin,
@@ -348,7 +348,7 @@ const defaultPlugins = [
     renderAfterEditable: PlateFloatingLink
   }),
   createKbdPlugin(),
-  createNodeIdPlugin(),
+//  createNodeIdPlugin(),
   createAutoformatPlugin({ options: optionsAutoformat }),
   createResetNodePlugin({ options: optionsResetBlockTypePlugin }),
   //createComboboxPlugin(),


### PR DESCRIPTION
this should get rid of the weird copy-paste bug we were seeing, though possibly not in documents that already exist - seems like a top level block with an id might replicate that id with the current version of the node-id plugin - disable node-id for now and we'll re-enable with the latest (not as buggy) version asap